### PR TITLE
ci: Update docker-release path filters

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -11,8 +11,6 @@ on:
         required: false
   pull_request:
     paths:
-      - Dockerfile
-      - .github/workflows/docker-release.yaml
       - "*.go"
       - "go.mod"
       - "go.sum"


### PR DESCRIPTION
Having the dockerfile and the workflow file as triggers, while it made sense in the beginning, ended up generating a lot of unnecessary releases.