### PR TITLE
ci(test): use talosctl cluster create docker subcommand

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -19,8 +19,8 @@ setup() {
     echo "========================================================================================="
     echo "Setting up Talos clusters..."
     echo "========================================================================================="
-    talosctl cluster create --name=talos-cluster-1 --talosconfig=$TALOSCONFIG_DIR/talos1.yaml --cidr=10.5.0.0/24 --wait=false &
-    talosctl cluster create --name=talos-cluster-2 --talosconfig=$TALOSCONFIG_DIR/talos2.yaml --cidr=10.6.0.0/24 --wait=false &
+    talosctl cluster create docker --name=talos-cluster-1 --talosconfig-destination=$TALOSCONFIG_DIR/talos1.yaml --subnet=10.5.0.0/24 &
+    talosctl cluster create docker --name=talos-cluster-2 --talosconfig-destination=$TALOSCONFIG_DIR/talos2.yaml --subnet=10.6.0.0/24 &
     wait
 
     echo "========================================================================================="


### PR DESCRIPTION
## Summary
- `talosctl` v1.12+ split `cluster create` into provisioner subcommands (`docker`/`qemu`/`dev`). The bare `cluster create` now aliases to `dev` (QEMU), which requires root — that's why CI was failing with `error: please run as root user (CNI, qemu hvf requirement)`.
- Switched `scripts/test.sh` to the explicit `cluster create docker` subcommand and its renamed flags (`--talosconfig-destination` instead of `--talosconfig`, `--subnet` instead of `--cidr`). The `docker` subcommand has no `--wait` flag and returns immediately, matching the old `--wait=false` behavior.

## Test plan
- [x] Verified locally with `talosctl` v1.13.5 against a real Docker daemon that `cluster create docker` no longer hits the root-permission error and correctly attempts to provision via Docker.
- [ ] Confirm the `Test` GitHub Actions workflow passes on this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EReD8ZaHSAYusQZumVHwXZ)_